### PR TITLE
normed epigraph distance

### DIFF
--- a/src/distances.jl
+++ b/src/distances.jl
@@ -15,14 +15,6 @@ Default distance function, implemented for all sets.
 struct DefaultDistance <: AbstractDistance end
 
 """
-    EpigraphViolationDistance
-
-Distance used when `v ∈ s` can be expressed as a single scalar function `f(v) ≤ 0`.
-The distance is expressed as `max(f(v), 0)`.
-"""
-struct EpigraphViolationDistance <: AbstractDistance end
-
-"""
     distance_to_set(distance_definition, v, s)
 
 Compute the distance of a value to a set.
@@ -34,3 +26,23 @@ with `T` of appropriate type for members of the set.
 function distance_to_set end
 
 distance_to_set(::AbstractDistance, v, s) = distance_to_set(DefaultDistance(), v, s)
+
+"""
+    EpigraphViolationDistance
+
+Distance used when `v ∈ s` can be expressed as a single scalar function `f(v) ≤ 0`.
+The distance is expressed as `max(f(v), 0)`.
+"""
+struct EpigraphViolationDistance <: AbstractDistance end
+
+"""
+    NormedEpigraphDistance{p}
+
+Distance used when `v ∈ s` can be expressed as a several functions `f_i(v) ≤ 0 ∀ i ∈ I`.
+The distance is expressed as `norm([max(f_i(v), 0) ∀ i ∈ I], n)` with `p` a norm value (2, 1, Inf).
+"""
+struct NormedEpigraphDistance{p} <: AbstractDistance end
+
+# _norm_set(::NormedEpigraphDistance{1}) = MOI.NormOneCone
+# _norm_set(::NormedEpigraphDistance{2}) = MOI.SecondOrderCone
+# _norm_set(::NormedEpigraphDistance{Inf}) = MOI.NormInfCone

--- a/src/distances.jl
+++ b/src/distances.jl
@@ -38,11 +38,7 @@ struct EpigraphViolationDistance <: AbstractDistance end
 """
     NormedEpigraphDistance{p}
 
-Distance used when `v ∈ s` can be expressed as a several functions `f_i(v) ≤ 0 ∀ i ∈ I`.
-The distance is expressed as `norm([max(f_i(v), 0) ∀ i ∈ I], n)` with `p` a norm value (2, 1, Inf).
+Distance used when `v ∈ s` can be expressed as the intersection of level sets `f_i(v) ≤ 0 ∀ i ∈ I`.
+The distance is expressed as `norm([max(f_i(v), 0) ∀ i ∈ I], n)` with `p` a norm value accepted by `LinearAlgebra.norm`.
 """
 struct NormedEpigraphDistance{p} <: AbstractDistance end
-
-# _norm_set(::NormedEpigraphDistance{1}) = MOI.NormOneCone
-# _norm_set(::NormedEpigraphDistance{2}) = MOI.SecondOrderCone
-# _norm_set(::NormedEpigraphDistance{Inf}) = MOI.NormInfCone

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -79,7 +79,8 @@ function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real},
     u = v[2]
     xs = v[3:end]
     return LinearAlgebra.norm(
-        (max(-t, zero(t)), max(-u, zero(u)), max(LinearAlgebra.dot(xs,xs) - 2 * t * u)), p
+        (max(-t, zero(t)), max(-u, zero(u)), max(LinearAlgebra.dot(xs,xs) - 2 * t * u)),
+        p,
     )
 end
 
@@ -110,7 +111,8 @@ function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real},
     z = v[3]
     result = y * exp(x/y) - z
     return LinearAlgebra.norm(
-        (max(-y, zero(result)), max(result, zero(result))), p,
+        (max(-y, zero(result)), max(result, zero(result))),
+        p,
     )
 end
 
@@ -125,7 +127,8 @@ function distance_to_set(::NormedEpigraphDistance{p}, vs::AbstractVector{<:Real}
     w = vs[3]
     result = -u*exp(v/u) - ℯ * w
     return LinearAlgebra.norm(
-        (max(u, zero(result)), max(result, zero(result))), p,
+        (max(u, zero(result)), max(result, zero(result))),
+        p,
     )
 end
 
@@ -158,7 +161,8 @@ function distance_to_set(::NormedEpigraphDistance{p}, vs::AbstractVector{<:Real}
     ce = 1-e
     result = abs(w) - (u/e)^e * (v/ce)^ce
     return LinearAlgebra.norm(
-        (max(-u, zero(result)), max(-v, zero(result)), max(result, zero(result))), p,
+        (max(-u, zero(result)), max(-v, zero(result)), max(result, zero(result))),
+        p,
     )
 end
 
@@ -178,7 +182,8 @@ function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real},
         push!(
             max.(v[2:end], zero(result)),
             max(result, zero(result)),
-        ), p,
+        ),
+        p,
     )
 end
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -9,19 +9,32 @@ function distance_to_set(::DefaultDistance, v::AbstractVector{T}, s::MOI.Reals) 
     return zero(T)
 end
 
-function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Zeros)
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, s::MOI.Zeros) where {p}
     _check_dimension(v, s)
-    return LinearAlgebra.norm2(v)
+    return LinearAlgebra.norm(v, p)
+end
+
+function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Zeros)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, s)
+end
+
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, s::MOI.Nonnegatives) where {p}
+    _check_dimension(v, s)
+    return LinearAlgebra.norm((ifelse(vi < 0, -vi, zero(vi)) for vi in v), p)
 end
 
 function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Nonnegatives)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, s)
+end
+
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, s::MOI.Nonpositives) where {p}
     _check_dimension(v, s)
-    return LinearAlgebra.norm2(ifelse(vi < 0, -vi, zero(vi)) for vi in v)
+    return LinearAlgebra.norm((ifelse(vi > 0, vi, zero(vi)) for vi in v), p)
 end
 
 function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Nonpositives)
     _check_dimension(v, s)
-    return LinearAlgebra.norm2(ifelse(vi > 0, vi, zero(vi)) for vi in v)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, s)
 end
 
 distance_to_set(::EpigraphViolationDistance, v::Real, s::MOI.LessThan) = max(v - s.upper, zero(v))
@@ -60,14 +73,18 @@ function distance_to_set(::DefaultDistance, v, s::Union{MOI.NormInfinityCone, MO
     return distance_to_set(EpigraphViolationDistance(), v, s)
 end
 
-function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.RotatedSecondOrderCone)
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, s::MOI.RotatedSecondOrderCone) where {p}
     _check_dimension(v, s)
     t = v[1]
     u = v[2]
     xs = v[3:end]
-    return LinearAlgebra.norm2(
-        (max(-t, zero(t)), max(-u, zero(u)), max(LinearAlgebra.dot(xs,xs) - 2 * t * u))
+    return LinearAlgebra.norm(
+        (max(-t, zero(t)), max(-u, zero(u)), max(LinearAlgebra.dot(xs,xs) - 2 * t * u)), p
     )
+end
+
+function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.RotatedSecondOrderCone)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, s)
 end
 
 function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.GeometricMeanCone)
@@ -86,26 +103,34 @@ function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Ge
     return max(result, zero(result))
 end
 
-function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.ExponentialCone)
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, s::MOI.ExponentialCone) where {p}
     _check_dimension(v, s)
     x = v[1]
     y = v[2]
     z = v[3]
     result = y * exp(x/y) - z
-    return LinearAlgebra.norm2(
-        (max(-y, zero(result)), max(result, zero(result)))
+    return LinearAlgebra.norm(
+        (max(-y, zero(result)), max(result, zero(result))), p,
     )
 end
 
-function distance_to_set(::DefaultDistance, vs::AbstractVector{<:Real}, s::MOI.DualExponentialCone)
+function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.ExponentialCone)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, s)
+end
+
+function distance_to_set(::NormedEpigraphDistance{p}, vs::AbstractVector{<:Real}, s::MOI.DualExponentialCone) where {p}
     _check_dimension(vs, s)
     u = vs[1]
     v = vs[2]
     w = vs[3]
     result = -u*exp(v/u) - ℯ * w
-    return LinearAlgebra.norm2(
-        (max(u, zero(result)), max(result, zero(result)))
+    return LinearAlgebra.norm(
+        (max(u, zero(result)), max(result, zero(result))), p,
     )
+end
+
+function distance_to_set(::DefaultDistance, vs::AbstractVector{<:Real}, s::MOI.DualExponentialCone)
+    return distance_to_set(NormedEpigraphDistance{2}(), vs, s)
 end
 
 function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.PowerCone)
@@ -124,7 +149,7 @@ function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, s::MOI.Po
     return max(result, zero(result))
 end
 
-function distance_to_set(::DefaultDistance, vs::AbstractVector{<:Real}, s::MOI.DualPowerCone)
+function distance_to_set(::NormedEpigraphDistance{p}, vs::AbstractVector{<:Real}, s::MOI.DualPowerCone) where {p}
     _check_dimension(vs, s)
     u = vs[1]
     v = vs[2]
@@ -132,12 +157,16 @@ function distance_to_set(::DefaultDistance, vs::AbstractVector{<:Real}, s::MOI.D
     e = s.exponent
     ce = 1-e
     result = abs(w) - (u/e)^e * (v/ce)^ce
-    return LinearAlgebra.norm2(
-        (max(-u, zero(result)), max(-v, zero(result)), max(result, zero(result)))
+    return LinearAlgebra.norm(
+        (max(-u, zero(result)), max(-v, zero(result)), max(result, zero(result))), p,
     )
 end
 
-function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, set::MOI.RelativeEntropyCone)
+function distance_to_set(::DefaultDistance, vs::AbstractVector{<:Real}, s::MOI.DualPowerCone)
+    return distance_to_set(NormedEpigraphDistance{2}(), vs, s)
+end
+
+function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{<:Real}, set::MOI.RelativeEntropyCone) where {p}
     _check_dimension(v, s)
     n = (dimension(set)-1) ÷ 2
     u = v[1]
@@ -145,10 +174,16 @@ function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, set::MOI.
     w = v[(n+2):end]
     s = sum(w[i] * log(w[i]/v[i]) for i in eachindex(w))
     result = s - u
-    return LinearAlgebra.norm2(push!(
-        max.(v[2:end], zero(result)),
-        max(result, zero(result)),
-    ))
+    return LinearAlgebra.norm(
+        push!(
+            max.(v[2:end], zero(result)),
+            max(result, zero(result)),
+        ), p,
+    )
+end
+
+function distance_to_set(::DefaultDistance, v::AbstractVector{<:Real}, set::MOI.RelativeEntropyCone)
+    return distance_to_set(NormedEpigraphDistance{2}(), v, set)
 end
 
 function distance_to_set(::EpigraphViolationDistance, v::AbstractVector{<:Real}, s::MOI.NormSpectralCone)


### PR DESCRIPTION
whenever a set is described as `fi(x) <= 0 for i in I`, defined the distance as a norm of the individual epigraph violations.

Many distance implementations are effectively following this guideline