### PR TITLE
Remove SCS specific scaling for PSD constraints

### DIFF
--- a/src/projections.jl
+++ b/src/projections.jl
@@ -116,12 +116,6 @@ NOTE: Now vectorization and scaling is not per SCS.
 Earlier used to be `vec(X) = (X11, sqrt(2)*X21, ..., sqrt(2)*Xk1, X22, sqrt(2)*X32, ..., Xkk)`
 """
 function vec_symm(X)
-#     @inbounds for i in 1:size(X)[1]
-#         for j in i+1:size(X)[2]
-#             X[i, j] *= √2
-#             X[j, i] *= √2
-#         end
-#     end
     return X[LinearAlgebra.tril(trues(size(X)))']
 end
 

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -76,28 +76,33 @@ end
 
 Returns a dim-by-dim symmetric matrix corresponding to `x`.
 
-`x` is a vector of length dim*(dim + 1)/2, corresponding to a symmetric
-matrix; the correspondence is as in SCS.
+`x` is a vector of length dim*(dim + 1)/2, corresponding to a symmetric matrix
 X = [ X11 X12 ... X1k
         X21 X22 ... X2k
         ...
         Xk1 Xk2 ... Xkk ],
 where
-vec(X) = (X11, sqrt(2)*X21, ..., sqrt(2)*Xk1, X22, sqrt(2)*X32, ..., Xkk)
+vec(X) = (X11, X21, ..., Xk1, X22, X32, ..., Xkk)
+
+NOTE: Now this is not specific to SCS/Mosek solver
+Earlier used to be: vec(X) = (X11, sqrt(2)*X21, ..., sqrt(2)*Xk1, X22, sqrt(2)*X32, ..., Xkk)
 """
 function unvec_symm(x, dim)
     X = zeros(dim, dim)
+    idx = 1
     for i in 1:dim
-        for j in i:dim
-            @inbounds X[j,i] = X[i,j] = x[(i-1)*dim-div((i-1)*i, 2)+j]
+        for j in 1:i
+            # @inbounds X[j,i] = X[i,j] = x[(i-1)*dim-div((i-1)*i, 2)+j]
+            @inbounds X[j,i] = X[i,j] = x[idx]
+            idx += 1 
         end
     end
-    for i in 1:dim
-        for j in i+1:dim
-            X[i, j] /= √2
-            X[j, i] /= √2
-        end
-    end
+#     for i in 1:dim
+#         for j in i+1:dim
+#             X[i, j] /= √2
+#             X[j, i] /= √2
+#         end
+#     end
     return X
 end
 
@@ -105,17 +110,19 @@ end
     vec_symm(X)
 
 Returns a vectorized representation of a symmetric matrix `X`.
-Vectorization (including scaling) as per SCS.
-`vec(X) = (X11, sqrt(2)*X21, ..., sqrt(2)*Xk1, X22, sqrt(2)*X32, ..., Xkk)`
+`vec(X) = (X11, X21, ..., Xk1, X22, X32, ..., Xkk)`
+
+NOTE: Now vectorization and scaling is not per SCS.
+Earlier used to be `vec(X) = (X11, sqrt(2)*X21, ..., sqrt(2)*Xk1, X22, sqrt(2)*X32, ..., Xkk)`
 """
 function vec_symm(X)
-    @inbounds for i in 1:size(X)[1]
-        for j in i+1:size(X)[2]
-            X[i, j] *= √2
-            X[j, i] *= √2
-        end
-    end
-    return X[LinearAlgebra.tril(trues(size(X)))]
+#     @inbounds for i in 1:size(X)[1]
+#         for j in i+1:size(X)[2]
+#             X[i, j] *= √2
+#             X[j, i] *= √2
+#         end
+#     end
+    return X[LinearAlgebra.tril(trues(size(X)))']
 end
 
 """

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -212,7 +212,7 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, ::M
     λ, U = LinearAlgebra.eigen(X)
 
     # if all the eigenvalues are >= 0
-    if all(λ .≥ zero(T))
+    if all(λi ≥ zero(λi) for λi in λ)
         return Matrix{T}(LinearAlgebra.I, n, n)
     end
 

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -218,7 +218,7 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, ::M
     λ, U = LinearAlgebra.eigen(X)
 
     # if all the eigenvalues are >= 0
-    if all(>=(0), λ)
+    if all(λ .≥ zero(T))
         return Matrix{T}(LinearAlgebra.I, n, n)
     end
 

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -39,7 +39,10 @@ end
                                                                                         0.25  0.0   0.0   0.0   0.5]
 
     # testing SDP trivial
-    @test MOD.projection_gradient_on_set(DD, ones(6), MOI.PositiveSemidefiniteConeTriangle(4)) ≈ Matrix{Float64}(LinearAlgebra.I, 6, 6)
+    # eye4 = Matrix{Float64}(LinearAlgebra.I, 4, 4)
+    eye4 = [1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]  # symmetrical PSD triangle format
+    eye10 = Matrix{Float64}(LinearAlgebra.I, 10, 10)
+    @test MOD.projection_gradient_on_set(DD, eye4, MOI.PositiveSemidefiniteConeTriangle(4)) ≈ eye10
 end
 
 @testset "Non-trivial joint projection" begin


### PR DESCRIPTION
As learned in https://github.com/jump-dev/MatrixOptInterface.jl/pull/7, code for MatOI, MOSD, and DiffOpt contained a lot of SCS specific code - which is now removed 

Since I was comparing DiffOpt results by diffcp, which was SCS styled. But I hand-derived a few examples (duals, slack variables and their derivatives) and now the updated gradients are much simpler to understand