### PR TITLE
Power Cone (WIP)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,9 +23,10 @@ julia = "1"
 
 [extras]
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
+Hypatia = "b99e6be6-89ff-11e8-14f8-45c827f4f8f2"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ChainRulesTestUtils", "JuMP", "SCS"]
+test = ["Test", "ChainRulesTestUtils", "Hypatia", "JuMP", "SCS"]

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -319,14 +319,14 @@ function _solve_system_pow_cone(v::AbstractVector{T}, s::MOI.PowerCone; max_iter
     px, py = zero(T), zero(T)
     r = abs(z) / 2
     for ii in 1:max_iters
-        px = Phi_prod(x,α,z,r)
-        py = Phi_prod(y,1-α,z,r)
+        px = Phi_prod(x, α, z, r)
+        py = Phi_prod(y, 1-α, z, r)
         phi = Phi(r, px, py)
 
         abs(phi) < tol && break
 
-        dpx = dPhi_prod_dr(x,α,z,r,px)
-        dpy = dPhi_prod_dr(y,1-α,z,r,py)
+        dpx = dPhi_prod_dr(x, α, z, r, px)
+        dpy = dPhi_prod_dr(y, 1-α, z, r, py)
         dphi = dPhi_dr(r,phi,px,py,dpx,dpy)
 
         # Newton step, bounded to interval

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -551,8 +551,8 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, s::
         return _pow_cone_∇proj_case_3(v, s)
     end
 
-    # x, y, z = v
-    # α = s.exponent
+    x, y, z = v
+    α = s.exponent
     # # This handles the case where v[3]/norm(v) is small.
     #   Phi(eps()) ≈ -r
     #   Phi_prod(x, α, z, eps()) ≈ x + |x| = 2*max(x, 0)

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -546,7 +546,7 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, s::
         # if in polar cone Ko = -K*
         return zeros(T, 3, 3)
     end
-    if abs(v[3]) <= 1e-10
+    if abs(v[3]) <= 1e-8
         return _pow_cone_∇proj_case_3(v, s)
     end
 

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -335,7 +335,7 @@ function _solve_system_pow_cone(v::AbstractVector{T}, s::MOI.PowerCone; max_iter
         ii == max_iters && @warn("Maximum iterations hit on power cone proj")
     end
 
-    return r, [0.5*px; 0.5*py; sign(z)*r]
+    return r, [0.5*px, 0.5*py, sign(z)*r]
 end
 
 """

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -410,10 +410,10 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, s::
     _check_dimension(v, s)
     Ip(z) = z >= 0 ? 1 : 0
 
-    if distance_to_set(DefaultDistance(), v, MOI.ExponentialCone()) < 1e-8
+    if _in_exp_cone(v; dual=false)
         return Matrix{T}(I, 3, 3)
     end
-    if distance_to_set(DefaultDistance(), -v, MOI.DualExponentialCone()) < 1e-8
+    if _in_exp_cone(-v; dual=true)
         # if in polar cone Ko = -K*
         return zeros(T, 3, 3)
     end
@@ -432,7 +432,7 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, s::
         0                  0                      1     -1
         exp_rs             (1-rs)*exp_rs          -1    0
     ])
-    return @view(mat[1:3,1:3])
+    return mat[1:3,1:3]
 end
 
 """

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -518,9 +518,9 @@ References:
 (https://stanford.edu/~boyd/papers/cone_prog_refine.html)
 by Enzo Busseti, Walaa M. Moursi, and Stephen Boyd
 """
-function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, ::MOI.DualExponentialCone) where {T}
+function projection_gradient_on_set(d::DefaultDistance, v::AbstractVector{T}, ::MOI.DualExponentialCone) where {T}
     # from Moreau decomposition: x = P_K(x) + P_-K*(x)
-    return I - projection_gradient_on_set(DefaultDistance(), -v, MOI.ExponentialCone())
+    return I - projection_gradient_on_set(d, -v, MOI.ExponentialCone())
 end
 
 """

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -585,7 +585,6 @@ end
 
 function _pow_cone_∇proj_case_3(v::AbstractVector{T}, s::MOI.PowerCone) where {T}
     x = [v[1]; v[2]]
-    I(t) = t > 0 ? 1 : 0
     αs = [s.exponent; 1-s.exponent]
 
     if sum(αs[x .> 0]) > sum(αs[x .< 0])
@@ -597,7 +596,7 @@ function _pow_cone_∇proj_case_3(v::AbstractVector{T}, s::MOI.PowerCone) where 
         denom = reduce(*, x[x .> 0].^αs[x .> 0]) * reduce(*, αs[x .< 0].^αs[x .< 0])
         d = 1/((num/denom)^2 + 1)
     end
-    return LinearAlgebra.diagm(0 => T[I(v[1]), I(v[2]), d])
+    return LinearAlgebra.diagm(0 => T[v[1] > 0, v[2] > 0, d])
 end
 
 """

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -305,7 +305,7 @@ References:
 [1]. [Differential properties of Euclidean projection onto power cone]
 (https://link.springer.com/article/10.1007/s00186-015-0514-0), Prop 2.2
 """
-function _solve_system_pow_cone(v::AbstractVector{T}, s::MOI.PowerCone; max_iters=200, tol=1e-8) where {T}
+function _solve_system_pow_cone(v::AbstractVector{T}, s::MOI.PowerCone; max_iters=500, tol=1e-10) where {T}
     x, y, z = v
     α = s.exponent
     Phi_prod(xi,αi,z,r) = max(xi + sqrt(xi^2 + 4*αi*r*(abs(z) - r)), 1e-12)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,5 @@
 
-function _bisection(f, left, right; max_iters=500, tol=1e-14)
+function _bisection(f, left, right; max_iters=10000, tol=1e-14)
     # STOP CODES:
     #   0: Success (floating point limit or exactly 0)
     #   1: Failure (max_iters without coming within tolerance of 0)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -6,7 +6,11 @@ function _bisection(f, left, right; max_iters=500, tol=1e-14)
 
     for _ in 1:max_iters
         f_left, f_right = f(left), f(right)
-        sign(f_left) == sign(f_right) && error("Interval became non-bracketing.")
+        sign(f_left) == sign(f_right) && error("
+            Interval became non-bracketing.
+            \nL: f($left) = $f_left
+            \nR: f($right) = $f_right"
+        )
 
         # Terminate if interval length ~ floating point precision (< eps())
         mid = (left + right) / 2

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -16,7 +16,7 @@ function _bisection(f, left, right; max_iters=500, tol=1e-14)
 
         # Terminate if within tol of 0; otherwise, bisect
         f_mid = f(mid)
-        if abs(f(mid)) < tol
+        if abs(f_mid) < tol
             return mid, 0
         end
         if sign(f_mid) == sign(f_left)

--- a/test/projection_gradients.jl
+++ b/test/projection_gradients.jl
@@ -173,9 +173,9 @@ end
     @testset "Exp Cone" begin
         function det_case_exp_cone(v; dual=false)
             v = dual ? -v : v
-            if MOD.distance_to_set(DD, v, MOI.ExponentialCone()) < 1e-8
+            if MOD._in_exp_cone(v; dual=false)
                 return 1
-            elseif MOD.distance_to_set(DD, -v, MOI.DualExponentialCone()) < 1e-8
+            elseif MOD._in_exp_cone(-v; dual=true)
                 return 2
             elseif v[1] <= 0 && v[2] <= 0 #TODO: threshold here??
                 return 3
@@ -212,6 +212,59 @@ end
                 grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, sd), v)[1]'
                 @test size(grad_fdm1) == size(grad_fdm2) == size(dΠ)
                 @test ≈(dΠ, grad_fdm1,atol=tol) || ≈(dΠ, grad_fdm2, atol=tol)
+            end
+        end
+        @test all(case_p .> 0) && all(case_d .> 0)
+    end
+
+    @testset "Power Cone" begin
+        function det_case_pow_cone(x, α; dual=false)
+            v = dual ? -x : x
+            s = MOI.PowerCone(α)
+            if MOD._in_pow_cone(v, s)
+                return 1
+            elseif MOD._in_pow_cone(-v, MOI.dual_set(s))
+                return 2
+            elseif abs(v[3]) <= 1e-8
+                return 3
+            else
+                return 4
+            end
+        end
+
+
+        case_p = zeros(4)
+        case_d = zeros(4)
+        Random.seed!(0)
+        rand_seeds = rand(1:1000, 100)
+        tol = 1e-5
+        for (ii, rseed) in enumerate(rand_seeds)
+            Random.seed!(rseed)
+            println("$ii, $rseed")
+            v = 5*randn(3)
+            for α in [0.5; rand(0.05:0.05:0.95)]
+                if ii % 10 == 1
+                    v[3] = 0.0
+                end
+                s = MOI.PowerCone(α)
+                sd = MOI.dual_set(s)
+                @testset "Primal Cone" begin
+                    case_p[det_case_pow_cone(v, α; dual=false)] += 1
+                    dΠ = MOD.projection_gradient_on_set(MOD.DefaultDistance(), v, s)
+                    grad_fdm1 = FiniteDifferences.jacobian(ffdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
+                    grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
+                    @test size(grad_fdm1) == size(grad_fdm2) == size(dΠ)
+                    @test ≈(dΠ, grad_fdm1,atol=tol) || ≈(dΠ, grad_fdm2, atol=tol)
+                end
+
+                @testset "Dual Cone" begin
+                    case_d[det_case_pow_cone(v, α; dual=true)] += 1
+                    dΠ = MOD.projection_gradient_on_set(MOD.DefaultDistance(), v, sd)
+                    grad_fdm1 = FiniteDifferences.jacobian(ffdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, sd), v)[1]'
+                    grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, sd), v)[1]'
+                    @test size(grad_fdm1) == size(grad_fdm2) == size(dΠ)
+                    @test ≈(dΠ, grad_fdm1,atol=tol) || ≈(dΠ, grad_fdm2, atol=tol)
+                end
             end
         end
         @test all(case_p .> 0) && all(case_d .> 0)

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -171,20 +171,21 @@ end
     atol = 2e-7
     case_p = zeros(4)
     case_d = zeros(4)
-    for _ in 1:200
+    for _ in 1:100
         x = randn(3)
-        α = rand(0.05:0.05:0.95)
+        for α in [rand(0.05:0.05:0.95); 0.5]
 
-        # Need to get some into case 3
-        if rand(1:10) == 1
-            x[3] = 0
+            # Need to get some into case 3
+            if rand(1:10) == 1
+                x[3] = 0
+            end
+
+            case_p[det_case_pow_cone(x, α; dual=false)] += 1
+            @test _test_proj_pow_cone_help(x, α, atol; dual=false)
+
+            case_d[det_case_pow_cone(x, α; dual=true)] += 1
+            @test _test_proj_pow_cone_help(x, α, atol; dual=true)
         end
-
-        case_p[det_case_pow_cone(x, α; dual=false)] += 1
-        @test _test_proj_pow_cone_help(x, α, atol; dual=false)
-
-        case_d[det_case_pow_cone(x, α; dual=true)] += 1
-        @test _test_proj_pow_cone_help(x, α, atol; dual=true)
     end
     @test all(case_p .> 0) && all(case_d .> 0)
 end

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -160,8 +160,12 @@ end
         z_star = value.(z)
         px = MOD.projection_on_set(DD, x, cone)
         if !isapprox(px, z_star, atol=tol)
-            # error("x = $x\nα = $α\nnorm = $(norm(px - z_star))\npx=$px\ntrue=$z_star")
+            error("x = $x\nα = $α\nnorm = $(norm(px - z_star))\npx=$px\ntrue=$z_star")
             return false
+       end
+       if !MOD._in_pow_cone(px, cone)
+           error("x = $x\nα = $α\nnorm = $(norm(px - z_star))\npx=$px\ntrue=$z_star")
+           return false
        end
        return true
     end

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -160,7 +160,7 @@ end
         z_star = value.(z)
         px = MOD.projection_on_set(DD, x, cone)
         if !isapprox(px, z_star, atol=tol)
-            println("x = $x\nα = $α\nnorm = $(norm(px - z_star))")
+            # error("x = $x\nα = $α\nnorm = $(norm(px - z_star))")
             return false
        end
        return true

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -160,7 +160,7 @@ end
         z_star = value.(z)
         px = MOD.projection_on_set(DD, x, cone)
         if !isapprox(px, z_star, atol=tol)
-            # error("x = $x\nα = $α\nnorm = $(norm(px - z_star))")
+            # error("x = $x\nα = $α\nnorm = $(norm(px - z_star))\npx=$px\ntrue=$z_star")
             return false
        end
        return true


### PR DESCRIPTION
Add power cone projection (working) and derivative of projection (some numerical errors).

Derivative of the projection is not working right now. Errors occur in case 4, when the algorithm cannot find a bounding interval for the bisection search. For example, the error can be reproduced in with the random seed below:
```Julia
Random.seed!(983)
v = randn(3)
α = rand(0.05:0.05:0.95)
s = MOI.PowerCone(α)
dΠ = MOD.projection_gradient_on_set(MOD.DefaultDistance(), v, s)
```

I have noticed that these errors occur when `\alpha` is `0.05` or `0.95` and `Phi(r)` is approximately `-r` since one of `x` or `y` is negative and `abs(z)` is small.
```Julia
  x, y, z = v
  α = s.exponent
  Phi_prod(xi,αi,z,r) = (xi + sqrt(xi^2 + 4*αi*r*(abs(z) - r)))
  Phi(r) = 0.5*(Phi_prod(x,α,z,r)^α * Phi_prod(y,1-α,z,r)^(1-α)) - r
```

Would appreciate any thoughts or ideas. The errors are relatively rare (15 of 200 tests). Some ideas I had:
* Check bounds to see if they are close to 0 (however doing this naively breaks the projection). Note that the solution interval for `Phi(r)` is `(0, abs(z)`
* Relatedly, use Newton's method instead of bisection, which will avoid the interval endpoint sign check
* Adjust the numerical tolerances; maybe expand case 3