### PR TITLE
norm ball and simplex projection

### DIFF
--- a/src/MathOptSetDistances.jl
+++ b/src/MathOptSetDistances.jl
@@ -10,6 +10,7 @@ const CRC = ChainRulesCore
 
 export distance_to_set, projection_on_set, projection_gradient_on_set
 
+include("sets.jl")
 include("utils.jl")
 include("distances.jl")
 include("distance_sets.jl")

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -511,8 +511,9 @@ end
 
 # initial implementation in FrankWolfe.jl
 function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::ProbabilitySimplex{T}) where {T}
+    _check_dimension(v, s)
     # TODO: allocating a ton, should implement the recent non-sorting alg
-    n = length(x)
+    n = length(v)
     if sum(v) ≈ s.radius && all(>=(0), v)
         return v
     end
@@ -525,6 +526,28 @@ function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::Probabili
     theta = (cssv[rho+1] - s.radius) / (rho + 1)
     w = clamp.(rev .- theta, 0.0, Inf)
     return w
+end
+
+function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::StandardSimplex{T}) where {T}
+    _check_dimension(v, s)
+    n = length(v)
+    if sum(v) ≤ s.radius && all(>=(0), v)
+        return v
+    end
+    x = copy(v)
+    sum_pos = zero(T)
+    for idx in eachindex(x)
+        if x[idx] < 0
+            x[idx] = 0
+        else
+            sum_pos += x[idx]
+        end
+    end
+    # at least one positive element
+    if sum_pos > 0
+        @. x = x / sum_pos * s.radius
+    end
+    return x
 end
 
 function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::NormInfinityBall{T}) where {T}

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -28,7 +28,7 @@ struct NormBallFromCone{T, S <: MOI.AbstractSet} <: MOI.AbstractScalarSet
 end
 
 const NormOneBall{T} = NormBallFromCone{T, MOI.NormOneCone}
-const NormInfBall{T} = NormBallFromCone{T, MOI.NormInfinityCone}
+const NormInfinityBall{T} = NormBallFromCone{T, MOI.NormInfinityCone}
 const NormTwoBall{T} = NormBallFromCone{T, MOI.SecondOrderCone}
 const NormNuclearBall{T} = NormBallFromCone{T, MOI.NormNuclearCone}
 

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -1,0 +1,36 @@
+
+"""
+Represents the standard simplex: `∑x_i ≤ radius, x_i ≥ 0`.
+"""
+struct StandardSimplex{T} <: MOI.AbstractScalarSet
+    dimension::Int
+    radius::T
+end
+
+"""
+Represents the probability simplex: `∑x_i == radius, x_i ≥ 0`.
+"""
+struct ProbabilitySimplex{T} <: MOI.AbstractScalarSet
+    dimension::Int
+    radius::T
+end
+
+MOI.constant(s::Union{StandardSimplex, ProbabilitySimplex}) = s.radius
+
+"""
+    NormBallFromCone{T, S}
+
+Represents a norm ball built from the corresponding cone with a fixed radius.
+"""
+struct NormBallFromCone{T, S <: MOI.AbstractSet} <: MOI.AbstractScalarSet
+    radius::Int
+    cone::S
+end
+
+const NormOneBall{T} = NormBallFromCone{T, MOI.NormOneCone}
+const NormInfBall{T} = NormBallFromCone{T, MOI.NormInfinityCone}
+const NormTwoBall{T} = NormBallFromCone{T, MOI.SecondOrderCone}
+const NormNuclearBall{T} = NormBallFromCone{T, MOI.NormNuclearCone}
+
+MOI.dimension(s::NormBallFromCone) = MOI.dimension(s) - 1
+MOI.constant(s::NormBallFromCone) = s.radius

--- a/src/sets.jl
+++ b/src/sets.jl
@@ -2,7 +2,7 @@
 """
 Represents the standard simplex: `∑x_i ≤ radius, x_i ≥ 0`.
 """
-struct StandardSimplex{T} <: MOI.AbstractScalarSet
+struct StandardSimplex{T} <: MOI.AbstractVectorSet
     dimension::Int
     radius::T
 end
@@ -10,19 +10,20 @@ end
 """
 Represents the probability simplex: `∑x_i == radius, x_i ≥ 0`.
 """
-struct ProbabilitySimplex{T} <: MOI.AbstractScalarSet
+struct ProbabilitySimplex{T} <: MOI.AbstractVectorSet
     dimension::Int
     radius::T
 end
 
 MOI.constant(s::Union{StandardSimplex, ProbabilitySimplex}) = s.radius
+MOI.dimension(s::Union{StandardSimplex, ProbabilitySimplex}) = s.dimension
 
 """
     NormBallFromCone{T, S}
 
 Represents a norm ball built from the corresponding cone with a fixed radius.
 """
-struct NormBallFromCone{T, S <: MOI.AbstractSet} <: MOI.AbstractScalarSet
+struct NormBallFromCone{T, S <: MOI.AbstractSet} <: MOI.AbstractVectorSet
     radius::Int
     cone::S
 end

--- a/test/projection_gradients.jl
+++ b/test/projection_gradients.jl
@@ -190,7 +190,7 @@ end
         case_p = zeros(4)
         case_d = zeros(4)
         # Adjust tolerance down because a 1-2 errors when projection ends up
-        #   very close to the z axis
+        # very close to the z axis
         # For intuition, see Fig 5.1 https://docs.mosek.com/modeling-cookbook/expo.html
         #   Note that their order is reversed: (x, y, z) = (x3, x2, x1) [theirs]
         tol = 1e-6

--- a/test/projection_gradients.jl
+++ b/test/projection_gradients.jl
@@ -13,6 +13,13 @@ const ffdm = FiniteDifferences.forward_fdm(5, 1)
 
 import ChainRulesCore
 const CRC = ChainRulesCore
+import FillArrays
+
+# type piracy because of https://github.com/JuliaDiff/FiniteDifferences.jl/issues/177
+function FiniteDifferences.to_vec(x::FillArrays.Zeros)
+    v = collect(x)
+    return v, _ -> error("can't create `Zeros` from a vector")
+end
 
 """
 A multivariate Gaussian generator without points too close to 0

--- a/test/projections.jl
+++ b/test/projections.jl
@@ -159,3 +159,34 @@ end
     end
     @test all(case_p .> 0) && all(case_d .> 0)
 end
+
+@testset "Simplex projections" begin
+    for n in (1, 2, 10)
+        for _ in 1:10
+            s = MOD.StandardSimplex(n, rand())
+            sp = MOD.ProbabilitySimplex(n, rand())
+            for _ in 1:5
+                v = 10 * randn(n)
+                p = MOD.projection_on_set(DD, v, s)
+                @test all(p .>= 0)
+                @test any(v .> 0) || sum(p) ≈ 0
+                if sum(p) > 0
+                    @test sum(p) ≈ min(s.radius, sum(abs, v))
+                end
+                p = MOD.projection_on_set(DD, v, sp)
+                @test all(p .>= 0)
+                @test sum(p) ≈ sp.radius
+                vu = rand(n)
+                vu ./= sum(vu)
+                vu .*= 0.9 * s.radius
+                @test vu ≈ MOD.projection_on_set(DD, vu, s)
+                vu ./= sum(vu)
+                vu .*= 0.9 * sp.radius
+                @test !≈(vu, MOD.projection_on_set(DD, vu, sp))
+                vu ./= sum(vu)
+                vu .*= sp.radius 
+                @test ≈(vu, MOD.projection_on_set(DD, vu, sp))
+            end
+        end
+    end
+end


### PR DESCRIPTION
with the recent work on FranWolfe.jl, I realized MOI has formulated many sets as cones, but not balls.
Of course formulations as balls are a special case with the epigraph variable being fixed to a scalar, but they offer many advantages (projections, linear minimization oracles, etc).

Also adds simplex sets. Things still missing include tests, differentiation.

Future work: implementing the SOTA projection onto L1 and simplex from https://link.springer.com/article/10.1007/s10107-015-0946-6