### PR TITLE
Fix warning about unused type parameter

### DIFF
--- a/src/projections.jl
+++ b/src/projections.jl
@@ -804,7 +804,7 @@ function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::StandardS
     return x
 end
 
-function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::NormInfinityBall{T}) where {T, R}
+function projection_on_set(::DefaultDistance, v::AbstractVector{T}, s::NormInfinityBall{R}) where {T, R}
     if norm(v, Inf) <= s.radius
         return v
     end


### PR DESCRIPTION
During precompilation, I got
```
WARNING: method definition for projection_on_set at /home/blegat/.julia/packages/MathOptSetDistances/pO2hs/src/projections.jl:807 declares type variable R but does not use it.
```
By the way, why not completely remove the parameters since they are not used in the function ?