### PR TITLE
Return Symmetric matrix in reshape_vector

### DIFF
--- a/src/projections.jl
+++ b/src/projections.jl
@@ -146,7 +146,8 @@ end
 """
     reshape_vector(x, set::MOI.AbstractSymmetricMatrixSetTriangle)
 
-Returns a dim-by-dim symmetric matrix corresponding to `x`.
+Returns a `dim`-by-`dim` symmetric matrix corresponding to `x` where
+`dim` is `MOI.side_dimension(set)`
 
 `x` is a vector of length dim*(dim + 1)/2, corresponding to a symmetric matrix
 ```
@@ -181,7 +182,7 @@ function reshape_vector(x, set::MOI.AbstractSymmetricMatrixSetTriangle)
             idx += 1
         end
     end
-    return X
+    return LinearAlgebra.Symmetric(X)
 end
 
 """


### PR DESCRIPTION
Otherwise, `eigen!(A)` will do `issymmetric` and then `eigen!(Symmetric(A))`, we can save the trouble here by directly wrapping it