### PR TITLE
vec_symm -> vectorize

### DIFF
--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -117,7 +117,7 @@ function CRC.frule((_, _, Δv, _), ::typeof(projection_on_set), d::DefaultDistan
         return (0 * v, 0 * Δv)
     end
     λp = max.(0, λ)
-    vproj = vec_symm(U * Diagonal(λp) * U')
+    vproj = vectorize(LinearAlgebra.Symmetric(U * Diagonal(λp) * U'))
     k = count(λi < 1e-4 for λi in λ)
     # TODO avoid full matrix materialize
     dim = MOI.side_dimension(set)
@@ -132,7 +132,7 @@ function CRC.frule((_, _, Δv, _), ::typeof(projection_on_set), d::DefaultDistan
         end
     end
     M = U * (B .* (U' * reshape_vector(Δv, set) * U)) * U'
-    Δvproj = vec_symm(M)
+    Δvproj = vectorize(LinearAlgebra.Symmetric(M))
     return (vproj, Δvproj)
 end
 

--- a/src/distance_sets.jl
+++ b/src/distance_sets.jl
@@ -278,7 +278,7 @@ function distance_to_set(::NormedEpigraphDistance{p}, v::AbstractVector{T}, s::M
     λ, U = LinearAlgebra.eigen(X)
     Tp = eltype(λ)
     λm = -min.(λ, zero(Tp))
-    vdist = vec_symm(U * LinearAlgebra.Diagonal(λm) * U')
+    vdist = vectorize(LinearAlgebra.Symmetric(U * LinearAlgebra.Diagonal(λm) * U'))
     return LinearAlgebra.norm(vdist, p)
 end
 

--- a/src/projections.jl
+++ b/src/projections.jl
@@ -129,7 +129,7 @@ function projection_on_set(::DefaultDistance, v::AbstractVector{T}, set::MOI.Pos
     X = reshape_vector(v, set)
     λ, U = LinearAlgebra.eigen(X)
     D = LinearAlgebra.Diagonal(max.(λ, 0))
-    return vec_symm(U * D * U')
+    return vectorize(LinearAlgebra.Symmetric(U * D * U'))
 end
 
 """
@@ -186,7 +186,7 @@ function reshape_vector(x, set::MOI.AbstractSymmetricMatrixSetTriangle)
 end
 
 """
-    vec_symm(X)
+    vectorize(X::LinearAlgebra.Symmetric)
 
 Returns a vectorized representation of a symmetric matrix `X`.
 `vec(X) = (X11, X12, X22, X13, X23, X33, ..., Xkk)`
@@ -197,8 +197,8 @@ Note that the scalar product for the symmetric matrix in its vectorized form is
 the sum of the pairwise product of the diagonal entries plus twice the sum of
 the pairwise product of the upper diagonal entries; see [p. 634, 1].
 Therefore, this transformation breaks inner products:
-```
-dot(vec_symm(X), vec_symm(Y)) != dot(X, Y).
+```julia
+dot(vectorize(X), vectorize(Y)) != dot(X, Y).
 ```
 
 ### References
@@ -206,8 +206,8 @@ dot(vec_symm(X), vec_symm(Y)) != dot(X, Y).
 [1] Boyd, S. and Vandenberghe, L.. *Convex optimization*. Cambridge university press, 2004.
 
 """
-function vec_symm(X)
-    return X[LinearAlgebra.triu(trues(size(X)))]
+function vectorize(X::LinearAlgebra.Symmetric)
+    return parent(X)[LinearAlgebra.triu(trues(size(X)))]
 end
 
 """
@@ -641,7 +641,7 @@ function projection_gradient_on_set(::DefaultDistance, v::AbstractVector{T}, set
                 end
             end
         end
-        @inbounds D[idx, :] = vec_symm(U * B * U')
+        @inbounds D[idx, :] = vectorize(LinearAlgebra.Symmetric(U * B * U'))
         # reset eigenvector
         @inbounds y[idx] = 0
     end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -134,7 +134,7 @@ end
             for _ in 1:5
                 L = 3 * tril(rand(n, n))
                 M = L * L'
-                v0 = MOD.vec_symm(M)
+                v0 = MOD.vectorize(LinearAlgebra.Symmetric(M))
                 v = Vector{Float64}(undef, length(v0))
                 Π = Vector{Float64}(undef, length(v0))
                 Δv = Vector{Float64}(undef, length(v0))
@@ -182,16 +182,16 @@ end
             ]
             Λ = Diagonal([-f, f])
             Λp = Diagonal([0, f])
-            v .= MOD.vec_symm(A)
+            v .= MOD.vectorize(LinearAlgebra.Symmetric(A))
             vproj = MOD.projection_on_set(DD, v, s)
             Π .= MOD.reshape_vector(vproj, MOI.PositiveSemidefiniteConeTriangle(2))
             @test Π ≈ Q * Λp * Qi
             DΠ .= MOD.projection_gradient_on_set(DD, v, s)
             for _ in 1:20
                 Xd .= ChainRulesTestUtils.rand_tangent(Π)
-                xd = MOD.vec_symm(Xd)
-                dir_deriv_theo = MOD.vec_symm(
-                    Q * (B .* (Q' * Xd * Q)) * Q'
+                xd = MOD.vectorize(LinearAlgebra.Symmetric(Xd))
+                dir_deriv_theo = MOD.vectorize(
+                    LinearAlgebra.Symmetric(Q * (B .* (Q' * Xd * Q)) * Q')
                 )
                 @test DΠ * xd ≈ dir_deriv_theo
                 (vproj_frule, Δvproj) = CRC.frule((CRC.NoTangent(), CRC.NoTangent(), xd, CRC.NoTangent()), MOD.projection_on_set, DD, v, s)

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -142,7 +142,7 @@ end
             for _ in 1:10
                 X .= randn(n, n)
                 X .= (X .+ X')
-                v = MOD.vec_symm(X)
+                v = MOD.vectorize(LinearAlgebra.Symmetric(X))
                 vproj = MOD.projection_on_set(MOD.DefaultDistance(), v, s)
                 dist = MOD.distance_to_set(MOD.DefaultDistance(), v, s)
                 @test LinearAlgebra.norm(v - vproj) ≈ dist atol=10e-5
@@ -151,13 +151,13 @@ end
                 λ = LinearAlgebra.eigvals(X)
                 if λ[1] >= 0
                     Xm = X - (λ[1] + λ[end])/2 * LinearAlgebra.I
-                    v = MOD.vec_symm(Xm)
+                    v = MOD.vectorize(LinearAlgebra.Symmetric(Xm))
                     vproj = MOD.projection_on_set(MOD.DefaultDistance(), v, s)
                     dist = MOD.distance_to_set(MOD.DefaultDistance(), v, s)
                     @test LinearAlgebra.norm(v - vproj) ≈ dist atol=10e-5
                 elseif λ[end] <= 0
                     Xp = X + (λ[1] + λ[end])/2 * LinearAlgebra.I
-                    v = MOD.vec_symm(Xp)
+                    v = MOD.vectorize(LinearAlgebra.Symmetric(Xp))
                     vproj = MOD.projection_on_set(MOD.DefaultDistance(), v, s)
                     dist = MOD.distance_to_set(MOD.DefaultDistance(), v, s)
                     @test LinearAlgebra.norm(v - vproj) ≈ dist atol=10e-5

--- a/test/projection_gradients.jl
+++ b/test/projection_gradients.jl
@@ -88,7 +88,7 @@ end
                 L = 3 * tril(rand(n, n))
                 M = L * L'
                 @testset "Positive definite" begin
-                    v = MOD.vec_symm(M)
+                    v = MOD.vectorize(LinearAlgebra.Symmetric(M))
                     dΠ = MOD.projection_gradient_on_set(MOD.DefaultDistance(), v, s)
                     grad_fdm1 = FiniteDifferences.jacobian(ffdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
                     grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
@@ -96,7 +96,7 @@ end
                     @test dΠ ≈ I
                 end
                 @testset "Negative definite" begin
-                    v = MOD.vec_symm(-M)
+                    v = MOD.vectorize(LinearAlgebra.Symmetric(-M))
                     dΠ = MOD.projection_gradient_on_set(MOD.DefaultDistance(), v, s)
                     grad_fdm1 = FiniteDifferences.jacobian(ffdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
                     grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
@@ -209,7 +209,7 @@ end
             Λ = Diagonal([-f, f])
             Λp = Diagonal([0, f])
             @test A ≈ Q * Λ * Qi
-            v = MOD.vec_symm(A)
+            v = MOD.vectorize(LinearAlgebra.Symmetric(A))
             Πv = MOD.projection_on_set(MOD.DefaultDistance(), v, s)
             Π = MOD.reshape_vector(Πv, MOI.PositiveSemidefiniteConeTriangle(2))
             @test Π ≈ Q * Λp * Qi
@@ -217,8 +217,9 @@ end
             # directional derivative
             for _ in 1:Ntrials
                 Xd = randn(2,2)
-                xd = MOD.vec_symm(Xd)
-                @test DΠ * xd ≈ MOD.vec_symm(Q * (B .* (Q' * Xd * Q)) * Q')
+                xd = MOD.vectorize(LinearAlgebra.Symmetric(Xd))
+                QBX = Q * (B .* (Q' * Xd * Q)) * Q'
+                @test DΠ * xd ≈ MOD.vectorize(LinearAlgebra.Symmetric(QBX))
             end
             grad_fdm1 = FiniteDifferences.jacobian(ffdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'
             grad_fdm2 = FiniteDifferences.jacobian(bfdm, x -> MOD.projection_on_set(MOD.DefaultDistance(), x, s), v)[1]'


### PR DESCRIPTION
In preparation for `Hermitian`. Then it will be `vectorize(::Symmetric)` gives the vectorization for symmetric and `vectorize(::Hermitian)` gives the vectorization for `Hermitian`. It is now consistent with `JuMP.vectorize` and `JuMP.reshape_vector`.