### PR TITLE
Bump compat in test/Project.toml

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -14,5 +14,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 FiniteDifferences = "0.12"
-Hypatia = "=0.7.0"
-SCS = "=1.1.0"
+Hypatia = "=0.7.4"
+SCS = "=2.0.0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -15,4 +15,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 FiniteDifferences = "0.12"
 Hypatia = "=0.7.4"
-SCS = "=2.0.0"
+SCS = "=1.1.0"


### PR DESCRIPTION
What is the motivation to lock these? It prevents things like fixes to Hypatia from propagating.

x-ref https://github.com/jump-dev/MathOptInterface.jl/actions/runs/7823304952/job/21344016059