### PR TITLE
Release PowerCone bisection code

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MathOptSetDistances"
 uuid = "3b969827-a86c-476c-9527-bb6f1a8fbad5"
 authors = ["Mathieu Besançon & contributors"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 BlockDiagonals = "0a1fb500-61f7-11e9-3c65-f5ef3456f9f0"


### PR DESCRIPTION
In theory, this is breaking because we changed the kwarg from `max_iters` to `max_iters_newton`.

But it is so minor that I would not update.

Moreover we are still in 0.x.y so we are allowed to break anything anytime.