### PR TITLE
Relax test tolerances

### DIFF
--- a/test/projections.jl
+++ b/test/projections.jl
@@ -275,7 +275,7 @@ end
 
     Random.seed!(0)
     n = 3
-    atol = 5e-6
+    atol = 1e-5
     case_p = zeros(4)
     case_d = zeros(4)
     for _ in 1:100


### PR DESCRIPTION
Tests are failing on Windows in https://github.com/matbesancon/MathOptSetDistances.jl/pull/91 because the tolerance is too tight